### PR TITLE
Fix shared waypoints not being saved to disk

### DIFF
--- a/src/main/java/com/muxiu1997/sharewhereiam/command/CommandWaypointSave.java
+++ b/src/main/java/com/muxiu1997/sharewhereiam/command/CommandWaypointSave.java
@@ -37,7 +37,7 @@ public class CommandWaypointSave extends CommandWaypointBase {
             sender.addChatMessage(new ChatComponentText(Lang.SAVE_WAYPOINT_EXISTS.translate()));
             return;
         }
-        WaypointStore.instance().add(waypoint);
+        WaypointStore.instance().save(waypoint);
         sender.addChatMessage(new ChatComponentText(Lang.SAVE_WAYPOINT_SUCCESS.translate()));
     }
 


### PR DESCRIPTION
Waypoints accepted from a chat share were only kept in memory, not written to disk, so they vanished on relog.

Fixes GTNewHorizons/GT-New-Horizons-Modpack#20805