### PR TITLE
Disable mod if JM6 is detected

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,6 @@
 dependencies {
-    compileOnly('com.github.GTNewHorizons:Navigator:1.1.4:dev') { transitive = false }
-    compileOnly('maven.modrinth:journeymap:v5.2.13')
+    compileOnly('com.github.GTNewHorizons:Navigator:1.1.5:dev') { transitive = false }
+    compileOnly('maven.modrinth:journeymap:5.2.20')
     compileOnly('curse.maven:xaeros-minimap-263420:5637000')
     compileOnly('curse.maven:xaeros-world-map-317780:5658209')
 }

--- a/src/main/java/com/muxiu1997/sharewhereiam/ShareWhereIAm.java
+++ b/src/main/java/com/muxiu1997/sharewhereiam/ShareWhereIAm.java
@@ -1,5 +1,6 @@
 package com.muxiu1997.sharewhereiam;
 
+import com.muxiu1997.sharewhereiam.integration.Mods;
 import com.muxiu1997.sharewhereiam.proxy.CommonProxy;
 
 import cpw.mods.fml.common.Mod;
@@ -22,11 +23,11 @@ public class ShareWhereIAm {
 
     @Mod.EventHandler
     public void init(FMLInitializationEvent event) {
-        proxy.init(event);
+        if (Mods.isEnabled()) proxy.init(event);
     }
 
     @Mod.EventHandler
     public void postInit(FMLPostInitializationEvent event) {
-        proxy.postInit(event);
+        if (Mods.isEnabled()) proxy.postInit(event);
     }
 }

--- a/src/main/java/com/muxiu1997/sharewhereiam/integration/Mods.java
+++ b/src/main/java/com/muxiu1997/sharewhereiam/integration/Mods.java
@@ -26,6 +26,6 @@ public enum Mods {
 
     public static boolean isEnabled() {
         return !Loader.isModLoaded("journeymap")
-                || Mods.class.getClassLoader().getResource("journeymap/api/v2/client/IClientAPI.class") == null;
+                || Mods.class.getClassLoader().getResource("journeymap/client/render/map/GridRenderer.class") != null;
     }
 }

--- a/src/main/java/com/muxiu1997/sharewhereiam/integration/Mods.java
+++ b/src/main/java/com/muxiu1997/sharewhereiam/integration/Mods.java
@@ -19,8 +19,13 @@ public enum Mods {
 
     public boolean isLoaded() {
         if (loaded == null) {
-            loaded = Loader.isModLoaded(modid);
+            loaded = Loader.isModLoaded(modid) && (this != JourneyMap || isEnabled());
         }
         return loaded;
+    }
+
+    public static boolean isEnabled() {
+        return !Loader.isModLoaded("journeymap")
+                || Mods.class.getClassLoader().getResource("journeymap/api/v2/client/IClientAPI.class") == null;
     }
 }

--- a/src/main/java/com/muxiu1997/sharewhereiam/mixinplugin/Mixins.java
+++ b/src/main/java/com/muxiu1997/sharewhereiam/mixinplugin/Mixins.java
@@ -4,6 +4,7 @@ import javax.annotation.Nonnull;
 
 import com.gtnewhorizon.gtnhmixins.builders.IMixins;
 import com.gtnewhorizon.gtnhmixins.builders.MixinBuilder;
+import com.muxiu1997.sharewhereiam.integration.Mods;
 
 public enum Mixins implements IMixins {
 
@@ -11,6 +12,7 @@ public enum Mixins implements IMixins {
     JOURNEYMAP_INTEGRATION(new MixinBuilder()
         .addRequiredMod(TargetedMod.JOURNEYMAP)
         .setPhase(Phase.LATE)
+        .setApplyIf(Mods.JourneyMap::isLoaded)
         .addClientMixins(
             "journeymap.MixinFullscreen",
             "journeymap.MixinRenderWaypointBeacon",
@@ -19,6 +21,7 @@ public enum Mixins implements IMixins {
     NAVIGATOR_INTEGRATION(new MixinBuilder()
         .addRequiredMod(TargetedMod.NAVIGATOR)
         .setPhase(Phase.LATE)
+        .setApplyIf(Mods::isEnabled)
         .addClientMixins("navigator.UniversalInteractableRendererAccessor"));
     // spotless:on
 


### PR DESCRIPTION
## Summary
This mod is made for Journeymap5, ensure it only run on this one.

If it try to mixin into JM6 it will just explode. Also JM6 seems to completely replicate all features of Share Where I am so make it fully no-op if it's present.


## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
